### PR TITLE
Update bootsnap gem to version 1.7.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 5.0'
 gem 'turbo-rails', '~> 0.7'
 gem 'jbuilder', '~> 2.7'
-gem 'bootsnap', '>= 1.4.4', require: false
+gem 'bootsnap', '>= 1.7.7', require: false
 gem 'stimulus-rails'
 
 gem 'rexml', '~> 3.2', '>= 3.2.4'


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zcyc/wblog/pull/1?shareId=b7800db6-ebed-4056-a711-2446d65b576c).